### PR TITLE
Add setup.ini for non-default setup configuration

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,3 @@
 *.phar
+setup.ini
 test.php

--- a/src/composer.iss
+++ b/src/composer.iss
@@ -12,6 +12,7 @@
 #define CS_SETUP_GUID "3ECDC245-751A-4962-B580-B8A250EDD1CF"
 #define GUID_LEN Len(CS_SETUP_GUID)
 
+#define SetupIni SourcePath	+ "\\setup.ini"
 
 [Setup]
 ; app name and version
@@ -55,15 +56,11 @@ VersionInfoProductName={#AppDescription}
 
 ; code-signing
 ;
-; NOTE:
-; code-signin requires a locally installed code-signing binary tool
-; that does not ship with this codebase, so you need to enable it if
-; you need it.
-; http://www.jrsoftware.org/ishelp/index.php?topic=setup_signtool
-; http://doughennig.blogspot.de/2009/11/executable-signing-with-inno-setup.html
-; http://margopowell.wordpress.com/2012/05/08/run-innosetup-with-digital-signature/
-;
-;SignTool=mssigntool
+; NOTE: see setup.ini
+#define SignTool ReadIni(SetupIni, "SignTool", "SignTool")
+#if SignTool != ""
+  SignTool={#SignTool}
+#endif
 
 ; cosmetic
 WizardImageFile=wiz.bmp

--- a/src/setup.ini.dist
+++ b/src/setup.ini.dist
@@ -1,0 +1,11 @@
+[SignTool]
+; NOTE:
+; code-signing requires a locally installed code-signing binary tool
+; that does not ship with this codebase, so you need to enable it if
+; you need it.
+;
+; http://www.jrsoftware.org/ishelp/index.php?topic=setup_signtool
+; http://doughennig.blogspot.de/2009/11/executable-signing-with-inno-setup.html
+; http://margopowell.wordpress.com/2012/05/08/run-innosetup-with-digital-signature/
+;
+SignTool=mssigntool


### PR DESCRIPTION
setup.ini is ignored, the inactive but copy under version control is
setup.ini.dist.

See #7

Usage: copy `setup.ini.dist` to `setup.ini` and change values as needed.
