### PR TITLE
getcomposer.org URLLabel branding for installer and uninstaller

### DIFF
--- a/src/composer.iss
+++ b/src/composer.iss
@@ -1542,7 +1542,10 @@ procedure URLLabelOnClick(Sender: TObject);
 var
   ErrorCode: Integer;
 begin
-  ShellExecAsOriginalUser('open', '{#AppUrl}', '', '', SW_SHOWNORMAL, ewNoWait, ErrorCode);
+  if IsUninstaller() then
+    ShellExec('open', '{#AppUrl}', '', '', SW_SHOWNORMAL, ewNoWait, ErrorCode)
+  else
+    ShellExecAsOriginalUser('open', '{#AppUrl}', '', '', SW_SHOWNORMAL, ewNoWait, ErrorCode);
 end;
 
 
@@ -1600,6 +1603,14 @@ begin
 
   CreateURLLabel(WizardForm, WizardForm.CancelButton);
 
+end;
+
+
+procedure InitializeUninstallProgressForm();
+begin
+  { Custom controls }
+
+  CreateURLLabel(UninstallProgressForm, UninstallProgressForm.CancelButton);
 end;
 
 


### PR DESCRIPTION
This experimental patch is adding a label with the text `getcomposer.org` (based on the AppUrl define) to the setup which can be clicked to visit the website.

![composer-setup-urllabel](https://f.cloud.github.com/assets/378849/105393/6791b8ea-69ac-11e2-9704-179dfcb91f04.png)
