### PR TITLE
Skip settings page if php.exe is as required

### DIFF
--- a/src/composer.iss
+++ b/src/composer.iss
@@ -167,6 +167,7 @@ var
   ErrorPage: TWizardPage;
   DownloadInfoPage: TWizardPage;
   FinishedInfoPage: TOutputMsgWizardPage;
+  SkipSettingsPage: Boolean;
 
 
 const
@@ -1521,6 +1522,8 @@ begin
   if Pos('/TEST', GetCmdTail) <> 0 then
     Test := TEST_FLAG;
 
+  SkipSettingsPage := (Test = '');
+
   Result := True;
 
 end;
@@ -1555,6 +1558,9 @@ begin
     SettingsPage.Add('', 'php.exe|php.exe', '.exe')
   else
     SettingsPage.Add('', 'All files|*.*', '');
+
+  if SkipSettingsPage and FileExists(PhpRec.Exe) then
+    SettingsPage.Values[0] := PhpRec.Exe;
 
   ErrorPage := CreateMessagePage(SettingsPage.ID,
     '', '', 'Please review and fix the issues listed below, then click Back and try again');
@@ -1620,6 +1626,16 @@ begin
 
   if PageID = ErrorPage.ID then
     Result := (PhpRec.Error = '') and (PathError = '')
+  else if SkipSettingsPage and (PageID = SettingsPage.ID) then
+  begin
+    SkipSettingsPage := False
+    if FileExists(SettingsPage.Values[0]) then
+      begin
+        ShowCheckPage()
+        if (PhpRec.Error = '') and (PathError = '') then
+          Result := True;
+      end
+  end
   else if PageID = DownloadInfoPage.ID then
     Result := GetRec.Text = ''
   else if PageId = FinishedInfoPage.ID then


### PR DESCRIPTION
This is a first PoC implementation of an idea I had to make the installation less cumbersome:

If the php.exe on the system is already configured as needed (the php version matches requirements and the `php` command is inside `%Path%`), the settings page to select the PHP binary must not be displayed (by default).

The results in one click less and the user must not decide which php.exe to pick if all is okay already.
