### PR TITLE
Compatibility with ANSI Inno Setup

### DIFF
--- a/src/paths.iss
+++ b/src/paths.iss
@@ -241,7 +241,7 @@ begin
       Value := '';
     end;
 
-    Inc(Next);
+    Next := Next + 1;
 
   until Length(Value) = 0;
 
@@ -350,7 +350,7 @@ begin
       begin
         SafeList.Items[Next].Hive := Hive;
         SafeList.Items[Next].Path := SafePath;
-        Inc(Next);
+        Next := Next + 1;
       end;
 
     end;

--- a/src/shutdown.iss
+++ b/src/shutdown.iss
@@ -255,7 +255,7 @@ begin
 
         if AppList[I].AppStatus = RmStatusRunning then
         begin
-          Inc(Count);
+          Count := Count + 1;
           SetArrayLength(RsRec.Apps, Count);
           RsRec.Apps[I] := RsToString(AppList[I].strAppName);
         end

--- a/src/userdata.iss
+++ b/src/userdata.iss
@@ -566,7 +566,7 @@ begin
       begin
         Sub := 'cache/config';
         Enabled := True;
-        Inc(Available);
+        Available := Available + 1;
         Form.ListBox.AddCheckBox('User: ' + List[I].User, Sub + ' data', 0, False, Enabled, False, True, TObject(I));
       end
       else
@@ -576,7 +576,7 @@ begin
         begin
           Sub := 'cache';
           Enabled := True;
-          Inc(Available);
+          Available := Available + 1;
           Form.ListBox.AddCheckBox('User: ' + List[I].User, Sub + ' data', 0, False, Enabled, False, True, TObject(I));
         end;
 


### PR DESCRIPTION
`Inc(value)` is no longer valid in ANSI Inno Setup.

https://github.com/jrsoftware/issrc/issues/35