### PR TITLE
Proper Cygwin handling

### DIFF
--- a/src/shims/composer
+++ b/src/shims/composer
@@ -2,7 +2,7 @@
 
 dir=$(cd "${0%[/\\]*}" > /dev/null; pwd)
 
-if [[ $dir == /cygdrive/* && $(which php) == /cygdrive/* ]]; then    
+if [[ $(uname -s) == CYGWIN_* ]]; then    
     # cygwin paths for windows PHP must be translated
     dir=$(cygpath -m "$dir");    
 fi


### PR DESCRIPTION
The `/cygdrive` prefix is not constant, as documented per link below:
https://cygwin.com/cygwin-ug-net/using.html#cygdrive

Hence the bash script should handle this more elegantly.