### PR TITLE
Make composer-shim POSIX-compatible

### DIFF
--- a/src/shims/composer
+++ b/src/shims/composer
@@ -2,9 +2,13 @@
 
 dir=$(cd "${0%[/\\]*}" > /dev/null; pwd)
 
-if [[ -d /proc/cygdrive && $(which php) == $(readlink -n /proc/cygdrive)/* ]]; then
-   # We are in Cgywin using Windows php, so the path must be translated
-   dir=$(cygpath -m "$dir");
+if [ -d /proc/cygdrive ]; then
+    case $(which php) in
+        $(readlink -n /proc/cygdrive)/*)
+            # We are in Cygwin using Windows php, so the path must be translated
+            dir=$(cygpath -m "$dir");
+            ;;
+    esac
 fi
 
 php "${dir}/composer.phar" "$@"


### PR DESCRIPTION
This shim file has `#!/bin/sh` declared as its shebang. However, it used a double bracket operator internally, which is a bashism and does not work in all shells that `/bin/sh` may represent.

AFAIU, the new version of the conditional should be equivalent but POSIX-compatible, and therefore work in all shells.