### PR TITLE
Correct invalid use of headers and improve install argument example

### DIFF
--- a/chocolatey/composer/ReadMe.md
+++ b/chocolatey/composer/ReadMe.md
@@ -4,12 +4,14 @@ Composer Setup downloads and installs the latest version of Composer, the PHP De
 
 Note: The version number refers to the installer and not to Composer, which you can update by running `composer self-update` from your terminal.
 
-##Package Specifics
+## Package Specifics
+
 This package has a dependency on the Chocolatey PHP package. If this is not found, the latest version will be downloaded and installed first.
 
 If you encounter any problems with the installation, you can run it interactively using the `--notsilent` option.
 
-##Advanced Usage
+## Advanced Usage
+
 The following package parameters can be set. They are mainly intended for CI usage:
 
 * `/DEV=path` - this installs Composer to the specified path, but without an uninstaller.

--- a/chocolatey/composer/ReadMe.md
+++ b/chocolatey/composer/ReadMe.md
@@ -12,10 +12,10 @@ If you encounter any problems with the installation, you can run it interactivel
 
 ## Advanced Usage
 
-The following package parameters can be set. They are mainly intended for CI usage:
+The following installer arguments can be set. They are mainly intended for CI usage:
 
 * `/DEV=path` - this installs Composer to the specified path, but without an uninstaller.
 * `/PHP=folder-or-exe` - this uses PHP from the specified location, adding it to the path.
 
 These parameters can be passed to the installer by using the `--ia` option.
-For example: --ia '"/DEV=C:\tools\php /PHP=C:\php"'.
+For example: `choco install --ia '"/DEV=C:\tools\php /PHP=C:\php"'`.


### PR DESCRIPTION
I noticed some invalid markdown when browsing the `composer` package on chocolatey.org
and figured to open a PR to fix those.

Also corrected the statement of using package parameters (which is untrue, as it is installer arguments) as well as improving a little on the example of passing the installer arguments.