### PR TITLE
Remove "using Windows PHP"-check from shim script

### DIFF
--- a/src/shims/composer
+++ b/src/shims/composer
@@ -3,12 +3,8 @@
 dir=$(cd "${0%[/\\]*}" > /dev/null; pwd)
 
 if [ -d /proc/cygdrive ]; then
-    case $(which php) in
-        $(readlink -n /proc/cygdrive)/*)
-            # We are in Cygwin using Windows php, so the path must be translated
-            dir=$(cygpath -m "$dir");
-            ;;
-    esac
+    # We are in Cygwin, so the path must be translated
+    dir=$(cygpath -m "$dir");
 fi
 
 php "${dir}/composer.phar" "$@"


### PR DESCRIPTION
Fixes #153.

This check was introduced in https://github.com/composer/windows-setup/commit/ae294139de418e4cdd75ea2c16d002e01702c629, but as far as I can tell "Cygwin PHP" understands Windows-style paths just fine, so the extra "Windows PHP"-check could be removed.