### PR TITLE
Fix "using Windows PHP in Cygwin"-check in shim script

### DIFF
--- a/src/shims/composer
+++ b/src/shims/composer
@@ -3,10 +3,16 @@
 dir=$(cd "${0%[/\\]*}" > /dev/null; pwd)
 
 if [ -d /proc/cygdrive ]; then
-    case $(which php) in
-        $(readlink -n /proc/cygdrive)/*)
-            # We are in Cygwin using Windows php, so the path must be translated
-            dir=$(cygpath -m "$dir");
+    cygwin_root=$(cygpath -m /)
+    php_bin=$(cygpath -m "$(which php)")
+
+    case "$php_bin" in
+        "$cygwin_root"/*)
+            # We are using Cygwin PHP, no action necessary
+            ;;
+        *)
+            # We are using Windows PHP, so the path must be translated
+            dir=$(cygpath -m "$dir")
             ;;
     esac
 fi


### PR DESCRIPTION
Fixes https://github.com/composer/windows-setup/issues/153.

This check was introduced in https://github.com/composer/windows-setup/commit/ae294139de418e4cdd75ea2c16d002e01702c629, but as far as I can tell "Cygwin PHP" understands Windows-style paths just fine, so the extra "Windows PHP"-check could be removed.

Supersedes #154, apparently GitHub trips if you rename a branch...