### PR TITLE
Resolve symlink to composer shell executable.

### DIFF
--- a/src/shims/composer
+++ b/src/shims/composer
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-dir=$(cd "${0%[/\\]*}" > /dev/null; pwd)
+self="$(readlink -m "$0")"
+dir=$(cd "${self%[/\\]*}" > /dev/null; pwd)
 
 if [ -d /proc/cygdrive ]; then
     cygwin_root=$(cygpath -m /)


### PR DESCRIPTION
Shell entry point for Composer used to resolve self-relative `composer.phar` file. However current code didn't handle symlinked `composer` file (e.g. useful when not adding `composer` to `$PATH`) and assumed `composer.phar` always shared symlink's base directory instead of target's one.

This PR adds missing symlink normalization using `readlink` to workaround this limitation.