### PR TITLE
Add zizmor security analysis + harden workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Compile Composer-Setup
         run: iscc src\composer.iss
-        shell: pwsh
+        shell: cmd
 
       - name: Build Chocolatey package
         if: matrix.install == 'choco'
@@ -44,8 +44,8 @@ jobs:
 
       - name: Install Composer-Setup.exe
         if: matrix.install == 'exe'
-        run: .\builds\output\Composer-Setup.dev.exe /VERYSILENT /SUPPRESSMSGBOXES /DEV=C:\composer /LOG=C:\install.txt
-        shell: pwsh
+        run: builds\output\Composer-Setup.dev.exe /VERYSILENT /SUPPRESSMSGBOXES /DEV=C:\composer /LOG=C:\install.txt
+        shell: cmd
 
       - name: Install Chocolatey package
         if: matrix.install == 'choco'
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run
         run: composer --version
-        shell: pwsh
+        shell: cmd
 
       - name: Run in bash
         run: composer --version

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -7,6 +7,13 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     name: Build & deploy
@@ -22,13 +29,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Compile Composer-Setup
         run: iscc src\composer.iss
-        shell: cmd
+        shell: pwsh
 
       - name: Build Chocolatey package
         if: matrix.install == 'choco'
@@ -36,8 +44,8 @@ jobs:
 
       - name: Install Composer-Setup.exe
         if: matrix.install == 'exe'
-        run: builds\output\Composer-Setup.dev.exe /VERYSILENT /SUPPRESSMSGBOXES /DEV=C:\composer /LOG=C:\install.txt
-        shell: cmd
+        run: .\builds\output\Composer-Setup.dev.exe /VERYSILENT /SUPPRESSMSGBOXES /DEV=C:\composer /LOG=C:\install.txt
+        shell: pwsh
 
       - name: Install Chocolatey package
         if: matrix.install == 'choco'
@@ -45,7 +53,7 @@ jobs:
         run: choco upgrade -y composer --source .\chocolatey\local --params '"/Dev:C:\composer"' --ia '"/LOG=C:\install.txt"'
 
       - name: Upload install log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: install-${{ matrix.install }}-log
           path: C:\install.txt
@@ -62,7 +70,7 @@ jobs:
 
       - name: Run
         run: composer --version
-        shell: cmd
+        shell: pwsh
 
       - name: Run in bash
         run: composer --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,13 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ini-tests:
     name: Ini Tests
@@ -28,12 +35,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: none
@@ -42,28 +50,28 @@ jobs:
         run: iscc src\composer.iss
 
       - name: Create log directory
-        run: mkdir ${{ env.LOG_DIR }}
+        run: mkdir %LOG_DIR%
 
       - name: Setup no-extensions
         run: php .github\workflows\ini-util.php --no-extensions
 
       - name: Test no-extensions
-        run:  ${{ env.SETUP_CMD }} /LOG=${{ env.LOG_DIR }}/no-extensions.txt
+        run:  %SETUP_CMD% /LOG=%LOG_DIR%/no-extensions.txt
 
       - name: Setup no-ini
         run: php .github\workflows\ini-util.php --no-ini
 
       - name: Test no-ini
-        run:  ${{ env.SETUP_CMD }} /LOG=${{ env.LOG_DIR }}/no-ini.txt
+        run:  %SETUP_CMD% /LOG=%LOG_DIR%/no-ini.txt
 
       - name: Setup wrong-extdir
         run: php .github\workflows\ini-util.php --wrong-extdir
 
       - name: Test wrong-extdir
-        run: ${{ env.SETUP_CMD }} /LOG=${{ env.LOG_DIR }}/wrong-extdir.txt
+        run: %SETUP_CMD% /LOG=%LOG_DIR%/wrong-extdir.txt
 
       - name: Upload install logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         with:
           name: install-${{ matrix.php-versions }}-log

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'


### PR DESCRIPTION
Adds a `zizmor` GitHub Actions security-analysis workflow (pedantic, matching `composer/packagist`) and a `dependabot.yml` (github-actions, monthly + 7-day cooldown), and hardens the existing workflows so zizmor passes:

- **Pinned** actions to commit SHAs at their latest releases (`actions/checkout`, `shivammathur/setup-php`, `actions/upload-artifact`).
- **Permissions**: explicit `contents: read`; added **concurrency** limits and `persist-credentials: false` on checkouts.
- **tests.yml**: reference the workflow `env` vars via cmd `%VAR%` syntax instead of `${{ env.* }}` in run blocks (avoids template injection; still cmd shell).
- **builds.yml**: switched the `iscc` / installer `.exe` / `composer --version` steps from `shell: cmd` to `shell: pwsh` (the `.exe` now uses a `.\` prefix) so zizmor can analyze them.

Verified locally with zizmor (pedantic, incl. online audits): no findings. The Windows build steps that changed shells are worth a close look in review since they couldn't be tested locally.